### PR TITLE
Allow Fastmail-operated domains incorrectly listed as disposable

### DIFF
--- a/allow-list.txt
+++ b/allow-list.txt
@@ -129,4 +129,8 @@ passfwd.com
 passmail.com
 passmail.net
 simplelogin.co
-simplelogin.io
+simplelogin.iofastmessaging.com
+mailhaven.com
+nospammail.net
+reallyfast.info
+veryfast.biz


### PR DESCRIPTION
Adds 5 Fastmail-operated domains to allow-list.txt to prevent them being 
included in the generated list.txt:

- fastmessaging.com
- mailhaven.com
- nospammail.net
- reallyfast.info
- veryfast.biz

These are privacy/alias domains offered as part of Fastmail's paid service 
(ASN 151847 - Fastmail Pty Ltd), not throwaway addresses. Editing allow-list.txt 
rather than list.txt directly, as list.txt is generated by sync.sh.

Relates to: https://github.com/kslr/disposable-email-domains/issues/73

**Domain verification (verifymail.io):**
- [x] [fastmessaging.com](https://verifymail.io/domain/fastmessaging.com) — Disposable: No, Provider: fastmail.com
- [x] [mailhaven.com](https://verifymail.io/domain/mailhaven.com) — Disposable: No, Provider: fastmail.com
- [x] [nospammail.net](https://verifymail.io/domain/nospammail.net) — Disposable: No, Provider: fastmail.com
- [x] [reallyfast.info](https://verifymail.io/domain/reallyfast.info) — Disposable: No, Provider: fastmail.com
- [x] [veryfast.biz](https://verifymail.io/domain/veryfast.biz) — Disposable: No, Provider: fastmail.com